### PR TITLE
fix(action-hub): pin Fastlane plugins + SHA-pin setup-ruby + canonicalize MATCH_GIT_PRIVATE_KEY ENV

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,96 @@
+# Composite action: Deploy iOS IPA to Firebase App Distribution
+# Patched for fastlane-modernization sub-plan 12:
+#   - AC18: pin firebase_app_distribution to --version=1.0.0
+#   - AC19: SHA-pin ruby/setup-ruby
+#   - AC20: rename MATCH_SSH_PRIVATE_KEY → MATCH_GIT_PRIVATE_KEY (canonical
+#           name flows across all actionhub repos + consumer dispatcher
+#           workflows). Backward-compat fallback retained for one release.
+name: 'Deploy iOS Firebase App Distribution'
+description: 'Build signed iOS IPA and deploy to Firebase App Distribution.'
+
+inputs:
+  ios_package_name:
+    description: 'iOS module name (e.g. cmp-ios)'
+    required: true
+  shared_module:
+    description: 'Gradle path to KMP shared module (e.g. :cmp-shared)'
+    required: true
+  use_cocoapods:
+    description: 'Install CocoaPods dependencies'
+    required: false
+    default: 'false'
+  appstore_key_id:
+    description: 'App Store Connect API key ID'
+    required: true
+  appstore_issuer_id:
+    description: 'App Store Connect issuer ID'
+    required: true
+  appstore_auth_key:
+    description: 'Base64-encoded .p8 App Store Connect API key'
+    required: true
+  match_password:
+    description: 'Fastlane Match passphrase'
+    required: true
+  match_git_private_key:
+    description: 'SSH private key for Match git repo (canonical ENV name — AC20)'
+    required: false
+  match_ssh_private_key:
+    description: 'DEPRECATED — use match_git_private_key. Kept for v1.x backward-compat; removed in v2.0.'
+    required: false
+  firebase_creds:
+    description: 'Base64-encoded Firebase service account JSON'
+    required: true
+  tester_groups:
+    description: 'Firebase tester group(s), comma-separated'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Ruby (SHA-pinned — AC19)
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f  # v1.232.0
+      with:
+        bundler-cache: true
+
+    - name: Install Fastlane plugins (pinned — AC18)
+      shell: bash
+      run: |
+        fastlane add_plugin firebase_app_distribution --version=1.0.0
+
+    - name: Inflate secrets
+      shell: bash
+      env:
+        APPSTORE_AUTH_KEY_B64: ${{ inputs.appstore_auth_key }}
+        # AC20 canonical name with v1.x fallback to the deprecated input.
+        MATCH_GIT_PRIVATE_KEY: ${{ inputs.match_git_private_key || inputs.match_ssh_private_key }}
+        FIREBASE_CREDS_B64: ${{ inputs.firebase_creds }}
+      run: |
+        mkdir -p secrets ~/.ssh
+        echo "$APPSTORE_AUTH_KEY_B64" | base64 --decode > secrets/AuthKey.p8
+        echo "$FIREBASE_CREDS_B64" | base64 --decode > secrets/firebaseAppDistributionServiceCredentialsFile.json
+        # Match SSH key — canonical ENV name
+        printf '%s' "$MATCH_GIT_PRIVATE_KEY" > secrets/match_ci_key
+        chmod 600 secrets/match_ci_key
+        cat > ~/.ssh/config <<'EOF'
+        Host github.com
+          IdentityFile $(pwd)/secrets/match_ci_key
+          StrictHostKeyChecking no
+        EOF
+
+    - name: Deploy to Firebase
+      shell: bash
+      env:
+        MATCH_PASSWORD: ${{ inputs.match_password }}
+        # Pass canonical name forward into Fastlane invocation.
+        MATCH_GIT_PRIVATE_KEY: ${{ inputs.match_git_private_key || inputs.match_ssh_private_key }}
+        FIREBASE_GROUPS: ${{ inputs.tester_groups }}
+        APPSTORE_KEY_ID: ${{ inputs.appstore_key_id }}
+        APPSTORE_ISSUER_ID: ${{ inputs.appstore_issuer_id }}
+      run: |
+        bundle exec fastlane ios deploy_on_firebase
+
+    - name: Cleanup secrets
+      shell: bash
+      if: always()
+      run: |
+        rm -f secrets/AuthKey.p8 secrets/firebaseAppDistributionServiceCredentialsFile.json secrets/match_ci_key


### PR DESCRIPTION
## Summary

Hardens this custom-action's `action.yml` ahead of the `fastlane-modernization` epic GA cut (consumer: [openMF/kmp-project-template](https://github.com/openMF/kmp-project-template)). Three coordinated fixes ship together — same shape as PR #47 (Xcode 26 fix → `v1.0.13`) on `mifos-x-actionhub-build-ios-app`.

### Fixes

- **AC18 — Pin `fastlane add_plugin` versions.** Every floating `fastlane add_plugin <name>` call now carries an explicit `--version=<X.Y.Z>` matching the Pluginfile entry. Notably `firebase_app_distribution --version=1.0.0` (bumped in epic sub-plan 01). `add_plugin` calls for plugins whose Fastfile usage was removed earlier in the epic — notably `increment_build_number` (sub-plan 05) — are dropped entirely rather than pinned to an unused version.
- **AC19 — SHA-pin `ruby/setup-ruby`.** Every `uses: ruby/setup-ruby@v1` is replaced with a 40-char commit SHA, with an inline comment recording the tag the SHA corresponds to (greppable for future bumps). The mutable `@v1` tag has been a long-standing supply-chain risk; this brings the action in line with the SHA-pinning posture already adopted across consumer-side workflows (per audit B4).
- **AC20 / upstream half of AC7 — Canonicalize Match Git-SSH ENV.** Match SSH input renamed `MATCH_SSH_PRIVATE_KEY` → `MATCH_GIT_PRIVATE_KEY` consistently across `inputs:`, `env:`, and `with:` passthroughs. A backward-compat fallback (`inputs.match_git_private_key || inputs.match_ssh_private_key`) keeps every existing caller working for the v1.x release line; the deprecated input is removed in `v2.0`. The consumer-side dispatcher workflows already write the canonical name (sub-plan 11 of the epic), so this is the upstream **reads** half — closing the cross-org name divergence.

### Verification

```bash
# AC19 — no floating ruby/setup-ruby tags remain
grep -c 'ruby/setup-ruby@v' action.yml          # expect: 0
grep -c 'ruby/setup-ruby@[0-9a-f]\{40\}' action.yml  # expect: ≥1

# AC20 — canonical ENV name is present and consistent
grep -c 'MATCH_GIT_PRIVATE_KEY' action.yml      # expect: ≥3 (input + env + with)
# Backward-compat: MATCH_SSH_PRIVATE_KEY may remain ONLY on the deprecated input row.

# AC18 — every add_plugin call is pinned
grep '^\s*fastlane add_plugin' action.yml | grep -v -- '--version=' || true  # expect: empty
```

### Tag target

After merge, this repo is tagged **`v1.0.14`** along with the other 9 hardened actionhub repos. The consumer (`openMF/kmp-project-template/.github/workflows/pr-check.yml`) then bumps its pin from `@v1.0.13` to `@v1.0.14` in a follow-up consumer-side PR.

### Refs

- Epic: [openMF/kmp-project-template fastlane-modernization](https://github.com/openMF/kmp-project-template) sub-plan 12
- Precedent: PR #47 on `mifos-x-actionhub-build-ios-app` (Xcode 26 fix → `v1.0.13`)
- Companion PRs: filed simultaneously against the other 9 affected `openMF/mifos-x-actionhub-*` repos

## Test plan

- [ ] CI green on this repo's smoke workflow (composite action loads without syntax error)
- [ ] One consumer dry-run from `openMF/kmp-project-template` against the PR branch confirms Fastlane lane execution still succeeds
- [ ] Backward-compat fallback exercised: caller passing the OLD `MATCH_SSH_PRIVATE_KEY` input still completes the lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)
