### PR TITLE
feat(action): add kmp_flavor input; set KMP_FLAVOR env for iOS Fastlane

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,10 @@ inputs:
   tester_groups:
     description: 'Firebase tester group(s), comma-separated'
     required: true
+  kmp_flavor:
+    description: 'Product flavor (e.g. prod, demo, bankA) — sets KMP_FLAVOR env var for Fastlane iOS lanes'
+    required: false
+    default: 'prod'
 
 runs:
   using: 'composite'
@@ -86,6 +90,7 @@ runs:
         FIREBASE_GROUPS: ${{ inputs.tester_groups }}
         APPSTORE_KEY_ID: ${{ inputs.appstore_key_id }}
         APPSTORE_ISSUER_ID: ${{ inputs.appstore_issuer_id }}
+        KMP_FLAVOR: ${{ inputs.kmp_flavor }}
       run: |
         bundle exec fastlane ios deploy_on_firebase
 


### PR DESCRIPTION
## Summary

- Adds `kmp_flavor` input (default: `prod`)
- Sets `KMP_FLAVOR` env var in the Deploy to Firebase step so iOS Fastlane lanes (e.g. `deploy_on_firebase`) can read `ENV['KMP_FLAVOR']` to select the correct flavor-specific Firebase iOS app ID or bundle configuration

## Test plan

- [ ] `kmp_flavor=prod` sets `KMP_FLAVOR=prod` in Fastlane env ✓
- [ ] `kmp_flavor=bankA` sets `KMP_FLAVOR=bankA` in Fastlane env ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)